### PR TITLE
feat(ui): 优先在 Windows 系统使用 Noto Sans 字体渲染

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -178,7 +178,14 @@ async function logout() {
   onLogout()
 }
 
+function detectOS() {
+  if (navigator.userAgent.indexOf('Windows') !== -1) {
+    document.documentElement.classList.add('is-windows')
+  }
+}
+
 onMounted(() => {
+  detectOS()
   loadSession()
   loadVersion()
 })

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,2 +1,6 @@
 @import "tailwindcss";
 @import "@nuxt/ui";
+
+.is-windows {
+  --font-sans: "Noto Sans SC", "Noto Sans CJK SC", "Microsoft YaHei", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+}


### PR DESCRIPTION
为了在 Windows 系统上获得更好的中文网页渲染效果，本 PR 增加了系统环境检测。当在 Windows 系统中访问页面时，会自动赋予 `.is-windows` 的 CSS 标识，并利用 Tailwind 的变量覆盖机制将 `--font-sans` 默认字体优先设置为 `Noto Sans SC` 和 `Noto Sans CJK SC`。这不会影响 macOS 和 Linux 用户的默认字体（如 PingFang SC）。

## 变更内容
- 在 `App.vue` 抽取并加入基于 `
avigator.userAgent` 的系统检测函数 `detectOS()`。
- 在 `index.css` 中为 `.is-windows` 指定 Noto Sans 优先的字体栈。



效果对比：
<img width="1304" height="530" alt="image" src="https://github.com/user-attachments/assets/78ee79d3-141d-4533-9411-ff449636884a" />
变更后：
<img width="1288" height="570" alt="image" src="https://github.com/user-attachments/assets/0cb906c3-bef0-4069-9e2c-0d9b15a420f2" />
