### PR TITLE
docs: 修复 README Star History 图表无法展示的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ docker compose logs -f cups
 
 <div align="center">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=hanxi/cups-web&type=Date)](https://www.star-history.com/#hanxi/cups-web&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=hanxi/cups-web&type=Date)](https://star-history.dera.page/#hanxi/cups-web&Date)
 
 如果这个项目对你有帮助，欢迎点击右上角的 ⭐ **Star** 让更多人发现它！
 


### PR DESCRIPTION
当前 README 中的 Star History 图表因 GitHub stargazer API 限制而无法正常展示。本 PR 将图表切换到 star-history.dera.page 替代服务，恢复项目 Star 趋势图的显示。